### PR TITLE
Allow cors to be set for dev mode. Nginx isnt there to set them for us

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "marked": "^0.3.2",
     "parseurl": "^1.0.1",
     "through": "^2.3.6",
-    "uglifyjs": "^2.3.6"
+    "uglifyjs": "^2.3.6",
+    "cors": "^2.5.2"
   }
 }

--- a/src/polymer-serve.litcoffee
+++ b/src/polymer-serve.litcoffee
@@ -47,9 +47,12 @@ Using cluster to get a faster build -- particularly on the initial request.
     else
       app = express()
       app.enable 'etag'
+      app.use require('cors')()
+
       app.use require('./polymer-middleware.litcoffee')(args, args.root_directory)
       app.use require('./style-middleware.litcoffee')(args, args.root_directory)
       app.use require('./script-middleware.litcoffee')(args, args.root_directory)
       app.use require('./markdown-middleware.litcoffee')(args, args.root_directory)
+
       app.use express.static(args.root_directory)
       app.listen port


### PR DESCRIPTION
We could check and only set them for 'dev/test/local' mode, but setting them in node shouldn't effect starphleet's nginx setting them.
