### PR TITLE
was attempting to send args.lastModified when not caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-serve",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Build tools to make polymer element creation easy!",
   "default": "index.js",
   "bin": {

--- a/src/markdown-middleware.litcoffee
+++ b/src/markdown-middleware.litcoffee
@@ -31,17 +31,16 @@ Express middleware to build and serve on demand.
           if 'GET' isnt req.method and 'HEAD' isnt req.method
             return next()
           filename = path.join directory or process.cwd(), parseurl(req).pathname
+          res.setHeader 'Last-Modified', args.lastModified ? new Date().toUTCString()
 
           if args.cache?[filename]
             res.type 'text/html'
-            res.setHeader 'Last-Modified', args.lastModified
             res.send args.cache[filename]
             return
 
           if path.extname(filename) is '.md'
             compile filename
               .then (content) ->
-                res.setHeader 'Last-Modified', args.lastModified
                 res.type 'text/html'
                 res.send(content).end()
               .error (e) ->

--- a/src/script-middleware.litcoffee
+++ b/src/script-middleware.litcoffee
@@ -57,17 +57,16 @@ Express middleware to build and serve on demand.
           if 'GET' isnt req.method and 'HEAD' isnt req.method
             return next()
           filename = path.join directory or process.cwd(), parseurl(req).pathname
+          res.setHeader 'Last-Modified', args.lastModified ? new Date().toUTCString()
 
           if path.extname(filename) is '.litcoffee' or path.extname(filename) is '.coffee'
             if args.cache?[filename]
               res.type 'application/javascript'
-              res.setHeader 'Last-Modified', args.lastModified
               res.send(args.cache[filename]).end()
               return
               
             compile filename
               .then (compiled) ->
-                res.setHeader 'Last-Modified', args.lastModified
                 res.type 'application/javascript'
                 res.send(compiled)
               .error (err) ->

--- a/src/style-middleware.litcoffee
+++ b/src/style-middleware.litcoffee
@@ -34,17 +34,16 @@ Express middleware to build and serve on demand.
           if 'GET' isnt req.method and 'HEAD' isnt req.method
             return next()
           filename = path.join directory or process.cwd(), parseurl(req).pathname
+          res.setHeader 'Last-Modified', args.lastModified ? new Date().toUTCString()
 
           if path.extname(filename) is '.less'
             if args.cache?[filename]
               res.type 'text/css'
-              res.setHeader 'Last-Modified', args.lastModified
               res.send(args.cache[filename]).end()
               return
             compile(filename)
               .then (compiled) ->
                 res.type 'text/css'
-                res.setHeader 'Last-Modified', args.lastModified
                 res.send(compiled).end()
               .error (e) ->
                 res.statusCode = 500


### PR DESCRIPTION
When not caching, there is no args.lastmodified, which was causing invalid behavior when I tried to set it inside the style compiler. Pulled up the lastmodified code to be set to “now” when not present on args.
